### PR TITLE
Bug 1442300 - Remove unused attribute --in-content-category from preferences.inc.css

### DIFF
--- a/browser/base/content/test/static/browser_parsable_css.js
+++ b/browser/base/content/test/static/browser_parsable_css.js
@@ -114,9 +114,6 @@ let whitelist = [
   // Bug 1441879
   {propName: "--arrow-width",
    isFromDevTools: true},
-  // Bug 1442300
-  {propName: "--in-content-category-background",
-   isFromDevTools: false},
 
   // Used on Linux
   {propName: "--in-content-box-background-odd",

--- a/browser/themes/shared/incontentprefs/preferences.inc.css
+++ b/browser/themes/shared/incontentprefs/preferences.inc.css
@@ -9,10 +9,6 @@
   -moz-user-select: text;
 }
 
-:root {
-  --in-content-category-background: #fafafc;
-}
-
 .main-content {
   padding-top: 0;
 }

--- a/doc/1442300.patch
+++ b/doc/1442300.patch
@@ -22,3 +22,26 @@ diff --git a/browser/themes/shared/incontentprefs/preferences.inc.css b/browser/
    /* A workaround to keep the container always float on the `top: 0` (Bug 1377009) */
    display: block;
    width: 664px;
+diff --git a/browser/themes/shared/incontentprefs/preferences.inc.css b/browser/themes/shared/incontentprefs/preferences.inc.css
+--- a/browser/base/content/test/static/browser_parsable_css.js
++++ b/browser/base/content/test/static/browser_parsable_css.js
+@@ -109,11 -109,8 @@
+  {propName: "--theme-search-overlays-semitransparent",
+   isFromDevTools: true},
+  // Bug 1441878
+  {propName: "--theme-codemirror-gutter-background",
+   isFromDevTools: true},
+  // Bug 1441879
+  {propName: "--arrow-width",
+   isFromDevTools: true},
+-  // Bug 1442300
+-  {propName: "--in-content-category-background",
+-   isFromDevTools: false},
+
+  // Used on Linux
+  {propName: "--in-content-box-background-odd",
+   platforms: ["win", "macosx"],
+   isFromDevTools: false},
+
+  // These properties *are* actually referenced. Need to find why
+  // their reference isn't getting counted.

--- a/doc/1442300.patch
+++ b/doc/1442300.patch
@@ -1,0 +1,24 @@
+diff --git a/browser/themes/shared/incontentprefs/preferences.inc.css b/browser/themes/shared/incontentprefs/preferences.inc.css
+--- a/browser/themes/shared/incontentprefs/preferences.inc.css
++++ b/browser/themes/shared/incontentprefs/preferences.inc.css
+@@ -4,20 +4,16 @@
+    - You can obtain one at http://mozilla.org/MPL/2.0/. */
+ %endif
+ @namespace html "http://www.w3.org/1999/xhtml";
+ 
+ * {
+   -moz-user-select: text;
+ }
+ 
+-:root {
+-  --in-content-category-background: #fafafc;
+-}
+-
+ .main-content {
+   padding-top: 0;
+ }
+ 
+ .pane-container {
+   /* A workaround to keep the container always float on the `top: 0` (Bug 1377009) */
+   display: block;
+   width: 664px;

--- a/doc/1442300.patch
+++ b/doc/1442300.patch
@@ -45,3 +45,4 @@ diff --git a/browser/themes/shared/incontentprefs/preferences.inc.css b/browser/
 
   // These properties *are* actually referenced. Need to find why
   // their reference isn't getting counted.
+  

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,0 +1,19 @@
+https://bugzilla.mozilla.org/show_bug.cgi?id=1442300
+
+## Diagnosis
+<!-- Diagnosis of your bug. Describe in English what the issue is, and what the benefit of fixing will bring. What risks are there, if any? -->
+The bug is that there is an attribute that is set but never referenced in the build. This causes the code base to be cluttered, and also raises warnings. There is a setting, --in-content-category on line 13 in the preferences.inc.css file that is never used.
+
+## Solution
+<!-- Propose a  solution. Describe in English what you’d do, and the step by step process you’d follow. The goal is to present your reasoning to the person who would be evaluating your patch. -->
+To solve this bug, I plan to first locate the preferences.inc.css file within the Firefox source code, and find the unnecessary code, which is the --in-content-category property. There is also another file which ensures that css files have proper formatting and conventions, browser_parsable_css.js, which has a whitelist of different unused properties based on bugs. On the gecko-dev version and my build, the whitelist in the file does not include the property, so there was nothing to edit for that.
+
+## Testing
+<!-- Testing document - A process (or description of a process) by which you’d evaluate the success of your work.  (See Note 1) How do you know your change addresses the bug?
+Screen shots, if necessary, showing issue and the correct behaviour with your fix applied. -->
+To check whether removing the code breaks anything, I have checked the rest of the source code for code that references or uses that part of the css file, and none do. Firefox still builds properly, and the behaviour of the program remains working after the bug fix.
+
+## Patch
+<!-- In separate text file, named doc/NNNN.patch (where NNNN is the bugzilla bug number).
+The patch, correctly formatted (See Note 2) -->
+https://github.com/csc302-winter-2018/a3-lukbria2-brianfluk/blob/master/1442300.patch

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -6,7 +6,7 @@ The bug is that there is an attribute that is set but never referenced in the bu
 
 ## Solution
 <!-- Propose a  solution. Describe in English what you’d do, and the step by step process you’d follow. The goal is to present your reasoning to the person who would be evaluating your patch. -->
-To solve this bug, I plan to first locate the preferences.inc.css file within the Firefox source code, and find the unnecessary code, which is the --in-content-category property. There is also another file which ensures that css files have proper formatting and conventions, browser_parsable_css.js, which has a whitelist of different unused properties based on bugs. On the gecko-dev version and my build, the whitelist in the file does not include the property, so there was nothing to edit for that.
+To solve this bug, I first located the preferences.inc.css file within the Firefox source code, and found the unnecessary code, which was the --in-content-category property. There was also another file which ensures that css files have proper formatting and conventions, browser_parsable_css.js, which has a whitelist of different unused properties based on bugs, so the entry for this bug was removed.
 
 ## Testing
 <!-- Testing document - A process (or description of a process) by which you’d evaluate the success of your work.  (See Note 1) How do you know your change addresses the bug?
@@ -16,4 +16,4 @@ To check whether removing the code breaks anything, I have checked the rest of t
 ## Patch
 <!-- In separate text file, named doc/NNNN.patch (where NNNN is the bugzilla bug number).
 The patch, correctly formatted (See Note 2) -->
-https://github.com/brianfluk/gecko-dev/blob/master/doc/1442300.patch
+https://github.com/csc302-winter-2018/a3-lukbria2-brianfluk/blob/master/1442300.patch

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -16,4 +16,4 @@ To check whether removing the code breaks anything, I have checked the rest of t
 ## Patch
 <!-- In separate text file, named doc/NNNN.patch (where NNNN is the bugzilla bug number).
 The patch, correctly formatted (See Note 2) -->
-https://github.com/csc302-winter-2018/a3-lukbria2-brianfluk/blob/master/1442300.patch
+https://github.com/brianfluk/gecko-dev/blob/master/doc/1442300.patch


### PR DESCRIPTION
Removed --in-content-category attribute on line 13 in preferences.inc.css, as it was defined but never referenced.